### PR TITLE
Add initial runit support

### DIFF
--- a/data/base/Packages-Live
+++ b/data/base/Packages-Live
@@ -1,6 +1,7 @@
 mkinitcpio-nfs-utils
 nbd
 >openrc artix-live-openrc
+>runit artix-live-runit
 squashfs-tools
 artix-live-portable-efi
 linux-lts-headers

--- a/data/base/Packages-Root
+++ b/data/base/Packages-Root
@@ -60,6 +60,19 @@ ntfs-3g
 >openrc rsync-openrc
 >openrc wpa_supplicant-openrc
 >openrc opentmpfiles
+>runit runit-artix
+>runit acpid-runit
+>runit cronie-runit
+>runit dbus-runit
+>runit dhcpcd-runit
+>runit elogind-runit
+>runit haveged-runit
+>runit lvm2-runit
+>runit mdadm-runit
+>runit nfs-utils-runit
+>runit rsync-runit
+>runit wpa_supplicant-runit
+>runit opentmpfiles
 os-prober
 pacman
 pciutils

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -139,6 +139,14 @@ add_svc_rc(){
     fi
 }
 
+add_svc_runit(){
+    local mnt="$1" name="$2"
+    if [[ -f $mnt/etc/runit/sv/$name ]]; then
+        msg2 "Setting %s ..." "$name"
+        chroot $mnt ln -s /etc/runit/sv/$name /etc/runit/runsvdir/default &>/dev/null
+    fi
+}
+
 set_xdm(){
     if [[ -f $1/etc/conf.d/xdm ]];then
         local conf='DISPLAYMANAGER="'${displaymanager}'"'
@@ -173,6 +181,14 @@ configure_services(){
                 add_svc_rc "$mnt" "$svc" "default"
             done
         ;;
+        'runit')
+            for svc in ${services[@]}; do
+                add_svc_runit "$mnt" "$svc"
+            done
+            for svc in ${services_live[@]}; do
+                add_svc_runit "$mnt" "$svc"
+            done
+        ;;
     esac
     info "Done configuring [%s]" "${initsys}"
 }
@@ -180,7 +196,7 @@ configure_services(){
 configure_system(){
     local mnt="$1"
     case ${initsys} in
-        'openrc')
+        'openrc' | 'runit')
             configure_logind "$mnt" "elogind"
         ;;
     esac

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -141,7 +141,7 @@ add_svc_rc(){
 
 add_svc_runit(){
     local mnt="$1" name="$2"
-    if [[ -f $mnt/etc/runit/sv/$name ]]; then
+    if [[ -d $mnt/etc/runit/sv/$name ]]; then
         msg2 "Setting %s ..." "$name"
         chroot $mnt ln -s /etc/runit/sv/$name /etc/runit/runsvdir/default &>/dev/null
     fi


### PR DESCRIPTION
(Do not merge yet, a test image will be generated in the upcoming days)

This PR is intended to add support for generating images for runit-based systems in Artix (and speed up the development for runit in Artix).

An .iso has been successfully generated, but it needs to be improved further.

Blockers:

- [x] artix-live one-shot initscript has no equivalent in runit yet
    (see https://github.com/artix-linux/live-services/pull/3)
- [x] can't add runit services to default runlevel yet
- [ ] runit doesn't have proper shutdown (or even booting) without manual intervention yet
    (binaries available, but they conflict with openrc. A solution has been proposed in the mailing list but in the meantime I'd like to make a package which is essentially just symlinks to the proper binary, which *will* conflict with openrc)
- TBA