### PR TITLE
Add support for one system with two inits

### DIFF
--- a/initcpio/hooks/artix_init
+++ b/initcpio/hooks/artix_init
@@ -1,0 +1,30 @@
+#!/usr/bin/ash
+
+run_latehook() {
+    local realroot=/new_root
+    local openrc="$realroot/bin/openrc-init"
+    local runit="$realroot/bin/runit-init"
+
+    if [ -x "$runit" ] && [ -x "$openrc" ]; then
+        msg ":: Currently available init:"
+        msg "   - openrc"
+        msg "   - runit"
+        while [ ! -L "$realroot/usr/bin/init" ]; do
+            msg ":: Please select your desired init:"
+            read -r INIT
+            if [ "$INIT" = "runit" ]; then
+                ln -s runit-init "$realroot/usr/bin/init"
+            elif [ "$INIT" = "openrc" ]; then
+                ln -s openrc-init "$realroot/usr/bin/init"
+            else
+                msg "Invalid choice."
+            fi
+        done
+    elif [ -x "$runit" ]; then
+        ln -s runit-init "$realroot/usr/bin/init"
+    elif [ -x "$openrc" ]; then
+        ln -s openrc-init "$realroot/usr/bin/init"
+    fi
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/initcpio/install/artix_init
+++ b/initcpio/install/artix_init
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+build() {
+    add_binary ln
+    add_runscript
+}
+
+help() {
+cat<<HELPEOF
+    This hook lets user choose their own init systems if /usr/bin/init
+    is not a symlink.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
This PR adds support so artools-iso can generate an ISO which should
work with two init systems.

However, eventually this PR will also report the progress of supporting two different init systems in Artix.

Prerequisites:
- [ ] No package owns sysvinit-compatible binaries like `/usr/bin/init`
  - Use [halt](https://github.com/arti-xlinux/halt) for wrappers around poweroff/shutdown/reboot
  - Use an alpm hook so when we detect two init systems installed we can make users choose which init to use on next reboot
    (However, this shouldn't trigger when we generate the ISOs so the users can choose them in initramfs via artix_init instead)
- [ ] Ensure that OpenRC and runit-artix (the *init* part of runit) doesn't conflict.

Live system:

- [x] Add init module for initramfs
- [ ] Add dual init option for artools
- [ ] Calamares support
  - Either we utilize the use of netgroups or we add a new module. This time when we add both package the alpm hook should be triggered.
- TBA
